### PR TITLE
Yves/fixes for perl 5 38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+blib/
+pm_to_blib
+Makefile
+META.*
+MYMETA.*
+*.bak
+*~

--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 Revision history for Perl module Carp::Assert
 
+0.22 2023-03-04
+    - Removed shouldn't. As of perl 5.37.9 use of apostrophe
+      as a package separator warns. As of 5.42 it will be removed.
+      Really Schwern, you should have resisted the urge. :-)
+    - Changed the Makefile.PL metadata to point at my repo, not
+      the Schwern repo.
+
 0.21 2014-06-25
     - Fixed typos in pod. RT#95017 - thanks Daniel Lintott.
     - Added links to a number of modules in SEE ALSO.

--- a/MANIFEST
+++ b/MANIFEST
@@ -7,3 +7,5 @@ lib/Carp/Assert.pm
 t/10enabled.t
 t/20disabled.t
 t/embedded-Carp-Assert.t
+META.yml                                 Module YAML meta-data (added by MakeMaker)
+META.json                                Module JSON meta-data (added by MakeMaker)

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,11 +1,11 @@
 Changes
 INSTALL
-MANIFEST
-Makefile.PL
-README
 lib/Carp/Assert.pm
+Makefile.PL
+MANIFEST
+META.json			Module JSON meta-data (added by MakeMaker)
+META.yml			Module YAML meta-data (added by MakeMaker)
+README
 t/10enabled.t
 t/20disabled.t
 t/embedded-Carp-Assert.t
-META.yml                                 Module YAML meta-data (added by MakeMaker)
-META.json                                Module JSON meta-data (added by MakeMaker)

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,9 @@
+.gitignore
+blib/
+MYMETA.*$
+.git
+.bak$
+MANIFEST.SKIP
+pm_to_blib
+Makefile$
+~$

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -49,8 +49,8 @@ WriteMakefile(
         resources => {
             repository  => {
                 type => 'git',
-                web  => 'https://github.com/schwern/Carp-Assert',
-                url  => 'git://github.com/schwern/Carp-Assert.git',
+                web  => 'https://github.com/demerphq/Carp-Assert',
+                url  => 'git://github.com/demerphq/Carp-Assert.git',
             },
         },
     })),
@@ -107,15 +107,24 @@ END_OF_MAKE
         my($self, $orig_perl, $tests) = @_;
 
         my @perls = ($orig_perl);
-        push @perls, qw(bleadperl
-                        perl5.6.1
-                        perl5.005_03
-                        perl5.004_05
-                        perl5.004_04
-                        perl5.004
-                       )
-          if $ENV{PERL_TEST_ALL};
-
+        if ($ENV{PERL_TEST_ALL} and $ENV{HOME}) {
+            chomp(my @list = `perlbrew list 2>&1`);
+            my %candidate;
+            foreach my $name (@list) {
+                $name=~s/^\s+//;
+                $name=~s/\s+\z//;
+                next unless $name =~ /^(perl-\d+\.\d+)\.(\d+)\z/
+                         or $name =~ /^(latest_blead)\z/;
+                my $major = $1;
+                my $minor = $2 // 0;
+                my $path = "$ENV{HOME}/perl5/perlbrew/perls/$name/bin/perl";
+                if (-e $path) {
+                    $candidate{$major} = [$minor, $path]
+                        if !$candidate{$major} or $candidate{$major}[0] < $minor;
+                }
+            }
+            push @perls, sort map { $_->[-1] } values %candidate;
+        }
         my $out;
         foreach my $perl (@perls) {
             $out .= $self->SUPER::test_via_harness($perl, $tests);

--- a/lib/Carp/Assert.pm
+++ b/lib/Carp/Assert.pm
@@ -8,7 +8,7 @@ use Exporter;
 use vars qw(@ISA $VERSION %EXPORT_TAGS);
 
 BEGIN {
-    $VERSION = '0.21';
+    $VERSION = '0.22';
 
     @ISA = qw(Exporter);
 
@@ -392,18 +392,6 @@ sub shouldnt ($$) {
     return undef;
 }
 
-# Sorry, I couldn't resist.
-sub shouldn't ($$) {     # emacs cperl-mode madness #' sub {
-    my $env_ndebug = exists $ENV{PERL_NDEBUG} ? $ENV{PERL_NDEBUG}
-                                              : $ENV{'NDEBUG'};
-    if( $env_ndebug ) {
-        return undef;
-    }
-    else {
-        shouldnt($_[0], $_[1]);
-    }
-}
-
 =back
 
 =head1 Debugging vs Production
@@ -518,11 +506,6 @@ Since C<POSIX> exports way too much, you should be using it like that anyway.
 
 affirm() mucks with the expression's caller and it is run in an eval
 so anything that checks $^S will be wrong.
-
-=head2 C<shouldn't>
-
-Yes, there is a C<shouldn't> routine.  It mostly works, but you B<must>
-put the C<if DEBUG> after it.
 
 =head2 missing C<if DEBUG>
 

--- a/lib/Carp/Assert.pm
+++ b/lib/Carp/Assert.pm
@@ -183,11 +183,11 @@ way, the assert() will give you a clue as to where the problem lies,
 rather than 50 lines down at when you wonder why your program isn't
 printing anything.
 
-Since assertions are designed for debugging and will remove themselves
+Since assertions are designed for debugging and will remove themelves
 from production code, your assertions should be carefully crafted so
 as to not have any side-effects, change any variables, or otherwise
 have any effect on your program.  Here is an example of a bad
-assertion:
+assertation:
 
     assert($error = 1 if $king ne 'Henry');  # Bad!
 

--- a/t/10enabled.t
+++ b/t/10enabled.t
@@ -3,7 +3,7 @@
 # Test with assert on.
 
 use strict;
-use Test::More tests => 8;
+use Test::More tests => 7;
 
 # Make sure we're shielded against the user possibly having
 # NDEBUG or PERL_NDEBUG set.  Localize the changes because changes
@@ -14,11 +14,6 @@ BEGIN {
     require Carp::Assert;
     Carp::Assert->import;
 }
-
-# shouldn't makes its decision at run-time
-local %ENV = %ENV;
-delete @ENV{qw(PERL_NDEBUG NDEBUG)};
-
 
 eval { assert(1==0) if DEBUG; };
 like $@, '/^Assertion failed/i';
@@ -45,8 +40,4 @@ is $@, '';
 
 
 eval { shouldnt('up', 'up') };
-like $@, '/^Assertion \(.*\) failed/i';
-
-
-eval { shouldn't('up', 'up') };
 like $@, '/^Assertion \(.*\) failed/i';

--- a/t/embedded-Carp-Assert.t
+++ b/t/embedded-Carp-Assert.t
@@ -1,0 +1,202 @@
+#!/usr/local/bin/perl -w
+
+use Test::More 'no_plan';
+
+package Catch;
+
+sub TIEHANDLE {
+	my($class, $var) = @_;
+	return bless { var => $var }, $class;
+}
+
+sub PRINT  {
+	my($self) = shift;
+	${'main::'.$self->{var}} .= join '', @_;
+}
+
+sub OPEN  {}    # XXX Hackery in case the user redirects
+sub CLOSE {}    # XXX STDERR/STDOUT.  This is not the behavior we want.
+
+sub READ {}
+sub READLINE {}
+sub GETC {}
+sub BINMODE {}
+
+my $Original_File = 'lib/Carp/Assert.pm';
+
+package main;
+
+# pre-5.8.0's warns aren't caught by a tied STDERR.
+$SIG{__WARN__} = sub { $main::_STDERR_ .= join '', @_; };
+tie *STDOUT, 'Catch', '_STDOUT_' or die $!;
+tie *STDERR, 'Catch', '_STDERR_' or die $!;
+
+{
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+#line 115 lib/Carp/Assert.pm
+
+BEGIN {
+    local %ENV = %ENV;
+    delete @ENV{qw(PERL_NDEBUG NDEBUG)};
+    require Carp::Assert;
+    Carp::Assert->import;
+}
+
+local %ENV = %ENV;
+delete @ENV{qw(PERL_NDEBUG NDEBUG)};
+
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+}
+
+{
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+#line 218 lib/Carp/Assert.pm
+my $life = 'Whimper!';
+ok( eval { assert( $life =~ /!$/ ); 1 },   'life ends with a bang' );
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+}
+
+{
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+#line 238 lib/Carp/Assert.pm
+{
+  package Some::Other;
+  no Carp::Assert;
+  ::ok( eval { assert(0) if DEBUG; 1 } );
+}
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+}
+
+{
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+#line 249 lib/Carp/Assert.pm
+ok( eval { assert(1); 1 } );
+ok( !eval { assert(0); 1 } );
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+}
+
+{
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+#line 259 lib/Carp/Assert.pm
+eval { assert(0) };
+like( $@, '/^Assertion failed!/',       'error format' );
+like( $@, '/Carp::Assert::assert\(0\) called at/',      '  with stack trace' );
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+}
+
+{
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+#line 274 lib/Carp/Assert.pm
+eval { assert( Dogs->isa('People'), 'Dogs are people, too!' ); };
+like( $@, '/^Assertion \(Dogs are people, too!\) failed!/', 'names' );
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+}
+
+{
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+#line 311 lib/Carp/Assert.pm
+my $foo = 1;  my $bar = 2;
+eval { affirm { $foo == $bar } };
+like( $@, '/\$foo == \$bar/' );
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+}
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+eval q{
+  my $example = sub {
+    local $^W = 0;
+
+#line 150 lib/Carp/Assert.pm
+
+    # Take the square root of a number.
+    sub my_sqrt {
+        my($num) = shift;
+
+        # the square root of a negative number is imaginary.
+        assert($num >= 0);
+
+        return sqrt $num;
+    }
+
+
+
+
+;
+
+  }
+};
+is($@, '', "example from line 150");
+
+{
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+#line 150 lib/Carp/Assert.pm
+
+    # Take the square root of a number.
+    sub my_sqrt {
+        my($num) = shift;
+
+        # the square root of a negative number is imaginary.
+        assert($num >= 0);
+
+        return sqrt $num;
+    }
+
+
+
+
+is( my_sqrt(4),  2,            'my_sqrt example with good input' );
+ok( !eval{ my_sqrt(-1); 1 },   '  and pukes on bad' );
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+}
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+eval q{
+  my $example = sub {
+    local $^W = 0;
+
+#line 301 lib/Carp/Assert.pm
+
+    affirm {
+        my $customer = Customer->new($customerid);
+        my @cards = $customer->credit_cards;
+        grep { $_->is_active } @cards;
+    } "Our customer has an active credit card";
+
+;
+
+  }
+};
+is($@, '', "example from line 301");
+
+    undef $main::_STDOUT_;
+    undef $main::_STDERR_;
+


### PR DESCRIPTION
Apostrophe has been deprecated in 5.37.8  and will be removed completely by 5.40. Its use in this module breaks things that use Carp::Assert even if they do not use shouldn't(). 

This also adds the missing files that were released to CPAN but not included in the repo, and adds a .gitignore, MANIFEST.SKIP and updates MANIFEST.

